### PR TITLE
Add 'view' field in AlertDetail serializer.

### DIFF
--- a/vigilate_backend/serializers.py
+++ b/vigilate_backend/serializers.py
@@ -123,7 +123,7 @@ class AlertSerializerDetail(serializers.ModelSerializer):
 
     class Meta:
         model = models.Alert
-        fields = ('id', 'user', 'program', 'cve')
+        fields = ('id', 'user', 'program', 'cve', 'view')
 
 
 class StationSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
The 'view' field in the AlertDetail is usefull to the frontend to know if it have to send a mark_read request or not.